### PR TITLE
fix warning in page build

### DIFF
--- a/_includes/JB/setup
+++ b/_includes/JB/setup
@@ -16,7 +16,7 @@
     {% if site.JB.ASSET_PATH %}
       {% assign ASSET_PATH = site.JB.ASSET_PATH %}
     {% else %}
-      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ page.theme.name }}{% endcapture %}
+      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ layout.theme.name }}{% endcapture %}
     {% endif %}  
   {% endif %}
 {% endcapture %}{% assign jbcache = nil %}


### PR DESCRIPTION
see email with previous build warning:

The page build completed successfully, but returned the following warning for the `master` branch:

You are currently using the Jekyll Bootstrap framework which has a known incompatibility with Jekyll v3.1. To fix this incompatibility, change `page.theme.name` in `_includes/JB/setup` to `layout.theme.name`. Your site may not build properly until this change has been applied. For more information, see https://jekyllrb.com/docs/upgrading/2-to-3/#layout-metadata.