### PR TITLE
fix build warning due to unsupported highlighting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,6 @@
 permalink: /:categories/:year/:month/:day/:title 
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
-pygments: true
 
 host: 192.168.1.13
 # Themes are encouraged to use these universal variables 


### PR DESCRIPTION
... returned the following warning for the `master` branch:

You are attempting to use the 'pygments' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml' and ensure the 'pygments' key is unset. For more information, see https://help.github.com/en/github/working-with-github-pages/troubleshooting-jekyll-build-errors-for-github-pages-sites#fixing-highlighting-errors.